### PR TITLE
Improve batch plan generation using total records

### DIFF
--- a/cloud-functions/batch_orchestrator_function/src/main.py
+++ b/cloud-functions/batch_orchestrator_function/src/main.py
@@ -117,21 +117,25 @@ def create_batch_plan(request_data):
             )
             start_row = 1
 
-        # APPROACH 1 (DISABLED): Calculate number of batches needed to process all records
-        # try:
-        #     total_records = int(total_records)
-        #     logger.info(f"DEBUG - batch_size: {batch_size}, total_records: {total_records}")
-        #     num_batches_needed = (total_records + batch_size - 1) // batch_size
-        #     logger.info(f"DEBUG - Total records: {total_records}, batch_size: {batch_size}, batches needed: {num_batches_needed}")
-        #     actual_batches_to_create = num_batches_needed
-        # except (ValueError, TypeError) as e:
-        #     logger.warning(f"Could not convert total_records to int. Error: {e}")
-
-        # APPROACH 2 (CURRENT): Create exactly max_concurrent_batches number of batches
-        actual_batches_to_create = max_concurrent_batches
-        logger.info(
-            f"DEBUG - max_concurrent_batches: {max_concurrent_batches}, actual_batches_to_create: {actual_batches_to_create}"
-        )
+        # Calculate number of batches needed to process all records starting from start_row
+        try:
+            total_records = int(total_records)
+            records_to_process = max(total_records - start_row + 1, 0)
+            num_batches_needed = (records_to_process + batch_size - 1) // batch_size
+            actual_batches_to_create = num_batches_needed
+            logger.info(
+                f"DEBUG - Total records: {total_records}, start_row: {start_row}, "
+                f"batch_size: {batch_size}, batches needed: {num_batches_needed}"
+            )
+        except (ValueError, TypeError) as e:
+            logger.warning(
+                f"Could not convert total_records to int. Error: {e}. "
+                "Defaulting to creating max_concurrent_batches only."
+            )
+            actual_batches_to_create = max_concurrent_batches
+            logger.info(
+                f"DEBUG - Fallback actual_batches_to_create: {actual_batches_to_create}"
+            )
 
         # Create batch plan
         pending_batches = []

--- a/workflows/ta-main-workflow.yaml
+++ b/workflows/ta-main-workflow.yaml
@@ -23,6 +23,20 @@ main:
           text: ${"BATCH DEBUG - execution_id " + execution_id + ", batch_size " + batch_size + ", start_row " + start_row + ", index_table " + index_table + ", output_table " + output_table + ", max_concurrent_workflows " + max_concurrent_workflows}
           severity: INFO
 
+    - get_total_records:
+        call: http.post
+        args:
+          url: ${"https://" + region + "-" + project_id + ".cloudfunctions.net/batch-orchestrator"}
+          auth:
+            type: OIDC
+            audience: ${"https://" + region + "-" + project_id + ".cloudfunctions.net/batch-orchestrator"}
+          body:
+            action: "get_total_records"
+            project_id: ${project_id}
+            dataset: ${dataset}
+            index_table: ${index_table}
+        result: total_records_resp
+
     - create_batch_plan:
         call: http.post
         args:
@@ -39,6 +53,7 @@ main:
             execution_id: ${default(execution_id, "")}
             max_concurrent_batches: ${max_concurrent_workflows}
             start_row: ${start_row}
+            total_records: ${total_records_resp.body.total_records}
         result: batch_plan
 
     - check_if_any_batches_to_process:


### PR DESCRIPTION
## Summary
- fetch total record count before creating batch plan
- compute full batch plan from total records and start row

## Testing
- `python -m py_compile cloud-functions/batch_orchestrator_function/src/main.py`
- `pytest` *(fails: fixture 'base_url' not found)*
- `pip install pyyaml` *(fails: Could not find a version that satisfies the requirement pyyaml)*

------
https://chatgpt.com/codex/tasks/task_e_68c54f40b1f0832d9fb270c5ce4b8816