### PR TITLE
chore: streamline runtime dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,40 +1,13 @@
-# Transcription Analytics Workflows - System Requirements
-# This file contains all Python dependencies for the entire system
+# Transcription Analytics Workflows - Runtime Requirements
+# Latest versions of Python packages required to run this project
 
-# Core Google Cloud libraries
-google-cloud-bigquery==3.13.0
-google-cloud-storage==2.10.0
-google-cloud-workflows==1.8.0
-google-cloud-aiplatform==1.38.0
-google-auth==2.23.4
-google-auth-oauthlib==1.1.0
-google-auth-httplib2==0.1.1
+functions-framework
+google-auth
+google-cloud-bigquery
+google-cloud-storage
+google-cloud-workflows
+google-genai
+pydantic
+psutil
+requests
 
-# Cloud Functions framework
-functions-framework==3.4.0
-
-# HTTP and API libraries
-requests==2.31.0
-urllib3==2.0.7
-
-# Data processing
-pandas==2.1.3
-numpy==1.25.2
-
-# JSON and data handling
-jsonschema==4.20.0
-
-# Logging and monitoring
-google-cloud-logging==3.8.0
-
-# Testing dependencies
-pytest==7.4.3
-pytest-mock==3.12.0
-
-# Development dependencies
-black==23.11.0
-flake8==6.1.0
-mypy==1.7.1
-
-# Optional: For advanced monitoring
-google-cloud-monitoring==2.16.0


### PR DESCRIPTION
## Summary
- prune development and unused packages from requirements
- specify core runtime dependencies without pinning versions

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest` *(fails: fixture 'base_url' not found in scripts/test_start_row.py)*

------
https://chatgpt.com/codex/tasks/task_e_68c55912e390832da8e02ad2f076346c