### PR TITLE
Limit sub-workflows for incremental runs

### DIFF
--- a/scripts/trigger_workflows.sh
+++ b/scripts/trigger_workflows.sh
@@ -39,15 +39,17 @@ trigger_master_orchestrator() {
     local max_concurrent=${2:-5}
     local start_row=${3:-1}
     local record_limit=${4:-0}
+    local max_batches=${5:-1000}
     local execution_id="manual_exec_$(date +%Y%m%d_%H%M%S)"
-    
+
     print_info "Triggering master orchestrator..."
     print_info "Execution ID: $execution_id"
     print_info "Batch size: $batch_size"
     print_info "Max concurrent: $max_concurrent"
     print_info "Start row: $start_row"
     print_info "Record limit: $record_limit"
-    
+    print_info "Max batches: $max_batches"
+
     gcloud workflows execute ta-main-workflow \
         --location=$REGION \
         --project=$PROJECT_ID \
@@ -64,9 +66,9 @@ trigger_master_orchestrator() {
             \"max_concurrent_workflows\": $max_concurrent,
             \"start_row\": $start_row,
             \"record_limit\": $record_limit,
-            \"max_batches\": 1000
+            \"max_batches\": $max_batches
         }"
-    
+
     print_status "Master orchestrator triggered successfully"
 }
 
@@ -135,9 +137,9 @@ trigger_incremental_run() {
     
     print_info "Will create $num_batches batches starting from row $start_row"
     print_info "Record limit set to $total_records (rows $start_row to $end_row)"
-    
-    # Trigger master orchestrator with start_row and record_limit parameters
-    trigger_master_orchestrator $batch_size $max_concurrent $start_row $total_records
+
+    # Trigger master orchestrator with start_row, record_limit, and max_batches parameters
+    trigger_master_orchestrator $batch_size $max_concurrent $start_row $total_records $num_batches
     
     print_status "Incremental run triggered successfully"
 }

--- a/workflows/ta-manager-workflow.yaml
+++ b/workflows/ta-manager-workflow.yaml
@@ -17,6 +17,7 @@ main:
     - init_chunk:
         assign:
           - chunk: []
+          - current_started_workflows: []
           - j: 0
 
     - fill_chunk_check:
@@ -39,7 +40,7 @@ main:
 
     - start_chunk_in_parallel:
         parallel:
-          shared: [all_started_workflows]
+          shared: [all_started_workflows, current_started_workflows]
           for:
             value: current_batch
             in: ${chunk}
@@ -59,9 +60,9 @@ main:
                             
                       - assign_step_by_step:
                           assign:
-                            - debug_start_row: ${current_batch[0].start_row}
-                            - debug_end_row: ${current_batch[0].end_row}
-                            - debug_batch_id: ${current_batch[0].batch_id}
+                            - debug_start_row: ${current_batch.start_row}
+                            - debug_end_row: ${current_batch.end_row}
+                            - debug_batch_id: ${current_batch.batch_id}
                             - where_clause: ${"WHERE row_num between " + string(debug_start_row) + " and " + string(debug_end_row)}
                             
                       - debug_after_batch_access:
@@ -113,6 +114,7 @@ main:
                           result: workflow_execution
                       - record_started_workflow:
                           assign:
+                            - current_started_workflows: ${list.concat(current_started_workflows, [workflow_execution.name])}
                             - all_started_workflows: ${list.concat(all_started_workflows, [workflow_execution.name])}
                   except:
                     as: error
@@ -123,6 +125,31 @@ main:
                             text: ${"ERROR - Failed to start worker sub-workflow for batch_id " + debug_batch_id + ". Details " + json.encode_to_string(error)}
                             severity: ERROR
 
+
+    - wait_for_chunk_completion:
+        for:
+          value: workflow_name
+          in: ${current_started_workflows}
+          steps:
+            - poll_workflow:
+                call: http.get
+                args:
+                  url: ${"https://workflowexecutions.googleapis.com/v1/" + workflow_name}
+                  auth:
+                    type: OAuth2
+                result: wf_status
+            - check_state:
+                switch:
+                  - condition: ${wf_status.body.state in ["SUCCEEDED", "FAILED", "CANCELLED"]}
+                    next: workflow_done
+                next: sleep_and_retry
+            - sleep_and_retry:
+                call: sys.sleep
+                args:
+                  seconds: 10
+                next: poll_workflow
+            - workflow_done:
+                nop: true
 
     - advance_window:
         assign:


### PR DESCRIPTION
## Summary
- ensure incremental run only creates expected number of batches
- expose max_batches and record_limit to main orchestrator and manager to clamp batch creation and respect concurrency

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement functions-framework (ProxyError: 403 Forbidden))*
- `pytest` *(fails: ModuleNotFoundError: No module named 'google'; No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_68c588674790832d850c3ce7c6392918